### PR TITLE
Add option to hide the battle mode pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2.4
 
+- Layout: Add option to hide the battle mode pill
 - Target tool: Add a link to CssBattle Previewer
 
 # 1.2.3

--- a/src/options-effect.css
+++ b/src/options-effect.css
@@ -134,6 +134,11 @@ body {
       display: none;
     }
   }
+  &.hideBattleModePill {
+    [class^="BattleModeInfoPill-module"] {
+      display: none !important;
+    }
+  }
   &.hideNbMinifiedCharacters {
     #nb-minified-characters {
       display: none;

--- a/src/options.html
+++ b/src/options.html
@@ -303,6 +303,10 @@
             <input type="checkbox" id="hideSponsor" />
             Hide sponsor
           </label>
+          <label>
+            <input type="checkbox" id="hideBattleModePill" />
+            Hide battle mode pill
+          </label>
         </fieldset>
         <fieldset>
           <legend>Editor button</legend>

--- a/src/options.js
+++ b/src/options.js
@@ -22,6 +22,7 @@ const OPTIONS_KEYS = [
   "hideFooter",
   "hideOutputCode",
   "hideTarget",
+  "hideBattleModePill",
 
   "hidePrettify",
   "hideMinify",


### PR DESCRIPTION
## Summary

- Adds a Layout option to hide the Code Golf / battle mode pill (`BattleModeInfoPill`) above the editor
- Uses a CSS-module-safe selector (`[class^="BattleModeInfoPill-module"]`) so it survives hash changes on cssbattle.dev

Closes #21

## Test plan

- [ ] Open extension options, enable **Hide battle mode pill** under Layout, save
- [ ] Reload a cssbattle.dev play page and confirm the golf banner is hidden
- [ ] Disable the option and confirm the banner returns
